### PR TITLE
requireDir() the template helpers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var postcss = require('gulp-postcss');
 var prefix = require('gulp-autoprefixer');
 var rename = require('gulp-rename');
 var reload = browserSync.reload;
+var requireDir = require('require-dir');
 var runSequence = require('run-sequence');
 var sass = require('gulp-sass');
 var webpack = require('webpack');
@@ -109,9 +110,7 @@ gulp.task('favicon', function () {
 gulp.task('assemble', function (done) {
 	assemble({
 		// apply additional helpers
-		helpers: {
-			ifEqual: require('./build/helpers/ifEqual')
-		}
+		helpers: requireDir('./build/helpers')
 	});
 	done();
 });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp-sass": "^1.3.3",
     "gulp-util": "^3.0.4",
     "imports-loader": "^0.6.3",
+    "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "script-loader": "^0.6.1",
     "webpack": "^1.8.3"


### PR DESCRIPTION
For issue #4 

As a first step to drying up the way template helpers are passed to the assembler, this PR introduces the use of `requireDir()`, enabling the entire tree of helpers to be retrieved at once instead of manually mapping each one.
