### PR TITLE
Helper to provide display names for patterns

### DIFF
--- a/build/helpers/displayName.js
+++ b/build/helpers/displayName.js
@@ -1,0 +1,5 @@
+'use strict';
+module.exports = function displayName(name) {
+  var pattern = /^[0-9]{0,4}[-_]?\s+?/;
+  return name.replace(pattern, '');
+};

--- a/src/views/layouts/includes/f-menu.html
+++ b/src/views/layouts/includes/f-menu.html
@@ -11,11 +11,11 @@
 
 		{{#each materials}}
 		<li>
-			<a href="{{@key}}.html" class="f-menu__heading">{{name}}</a>
+			<a href="{{@key}}.html" class="f-menu__heading">{{ displayName name}}</a>
 			<ul>
 				{{#each items}}
 				<li>
-					<a href="{{@../key}}.html#{{@key}}">{{name}}</a>
+					<a href="{{@../key}}.html#{{@key}}">{{ displayName name}}</a>
 				</li>
 				{{/each}}
 			</ul>
@@ -24,11 +24,11 @@
 
 		{{#each views}}
 		<li>
-			<a href="{{@key}}.html" class="f-menu__heading">{{name}}</a>
+			<a href="{{@key}}.html" class="f-menu__heading">{{ displayName name}}</a>
 			<ul>
 				{{#each items}}
 				<li>
-					<a href="{{@../key}}/{{@key}}.html">{{name}}</a>
+					<a href="{{@../key}}/{{@key}}.html">{{ displayName name}}</a>
 				</li>
 				{{/each}}
 			</ul>
@@ -40,7 +40,7 @@
 			<ul>
 				{{#each docs}}
 				<li>
-					<a href="docs.html#{{@key}}">{{name}}</a>
+					<a href="docs.html#{{@key}}">{{ displayName name}}</a>
 				</li>
 				{{/each}}
 			</ul>


### PR DESCRIPTION
This PR introduces a new Handlebars helper that can allow us to do custom ordering of patterns the way we did on VSE.

You can now name patterns prefixed with `ddd-` for ordering, e.g. `01-hi.html` and they will display in the nav menu with prettier names. The helper `displayName` is available to any fabricator template now.
