### PR TITLE
Removing color overrides for f-Item-control elements

### DIFF
--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -272,7 +272,7 @@ fabricator.singleItemToggle = function () {
 	var toggleSingleItemCode = function (e) {
 		var group = this.parentNode.parentNode.parentNode,
 			type = e.currentTarget.getAttribute('data-f-toggle-control');
-
+		e.preventDefault();
 		group.querySelector('[data-f-toggle=' + type + ']').classList.toggle('f-u-hidden');
 	};
 

--- a/src/assets/fabricator/styles/base/variables.css
+++ b/src/assets/fabricator/styles/base/variables.css
@@ -2,7 +2,6 @@
 	--Layout-nav-width: 14rem;
 
 	--Item-border: #ccc;
-	--Item-control-color: #0074D9;
 
 	--Nav-background: #444;
 	--Nav-hover-background: #333;

--- a/src/assets/fabricator/styles/components/item.css
+++ b/src/assets/fabricator/styles/components/item.css
@@ -53,7 +53,6 @@
   line-height: 1;
   vertical-align: baseline;
   text-decoration: none;
-  color: var(--Item-control-color);
   border: 0;
   background-color: transparent;
   cursor: pointer;

--- a/src/views/layouts/includes/f-item-content.html
+++ b/src/views/layouts/includes/f-item-content.html
@@ -3,12 +3,12 @@
 </div>
 <ul class="f-Item-controls f-u-listInline">
 	<li>
-		<button class="f-Item-control" data-f-toggle-control="code">
+		<a href="#{{@key}}-source" class="f-Item-control" data-f-toggle-control="code">
 			<svg>
 				<use xlink:href="#f-icon-code" />
 			</svg>
 			Source
-		</button>
+		</a>
 	</li>
 	{{#each data.links}}
 		<li>
@@ -21,6 +21,6 @@
 		</li>
 	{{/each}}
 </ul>
-<div class="f-Item-code f-u-hidden" data-f-toggle="code">
+<div id="{{@key}}-source" class="f-Item-code f-u-hidden" data-f-toggle="code">
 	<pre><code class="language-markup">{{material @key @root}}</code></pre>
 </div>


### PR DESCRIPTION
In general, our theme inherits most of its characteristics from `toolkit.css`, which will make it work nicely with projects of varying stylistic requirements. One notable exception to this were the `.f-Item-control` elements, which had a defined text color that had to be customized in order to synchronize with the surrounding UI.

I realized that the "source" link, which was previously a button, could easily be changed to a link while remaining semantic by assigning source elements an ID. When all controls are links, they can inherit the typical link color of the design.
