### PR TITLE
Labels!

### DIFF
--- a/src/assets/fabricator/styles/base/variables.css
+++ b/src/assets/fabricator/styles/base/variables.css
@@ -7,6 +7,10 @@
 	--Nav-background: #444;
 	--Nav-hover-background: #333;
 	--Nav-color: #fff;
+
+	--Label-inprogress: #ffd739;
+	--Label-deprecated: #ff4136;
+	--Label-approved: #19b72b;
 }
 
 @custom-media --large-viewport (min-width: 60em);

--- a/src/assets/fabricator/styles/components/item.css
+++ b/src/assets/fabricator/styles/components/item.css
@@ -32,10 +32,22 @@
   margin-bottom: 2rem;
 }
 
-.f-Item-heading {
+.f-Item-heading,
+.f-Item-labels {
   margin-top: 0;
   margin-bottom: 0;
+  display: inline-block;
+}
+
+.f-Item-heading {
+  margin-right: 1rem;
   line-height: 1;
+}
+
+.f-Item-labels > li {
+  position: relative;
+  top: -0.2rem;
+  margin-top: 0.5rem;
 }
 
 .f-Item-notes {

--- a/src/assets/fabricator/styles/components/label.css
+++ b/src/assets/fabricator/styles/components/label.css
@@ -1,0 +1,24 @@
+.f-Label {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+  background-color: rgba(0,0,0,0.1);
+}
+
+.f-Label--deprecated,
+.f-Label--approved {
+  color: #fff;
+}
+
+.f-Label--inprogress {
+  background-color: var(--Label-inprogress);
+}
+
+.f-Label--deprecated {
+  background-color: var(--Label-deprecated);
+}
+
+.f-Label--approved {
+  background-color: var(--Label-approved);
+}

--- a/src/assets/fabricator/styles/fabricator.css
+++ b/src/assets/fabricator/styles/fabricator.css
@@ -7,6 +7,7 @@
 @import 'base/variables';
 
 @import 'components/item';
+@import 'components/label';
 @import 'components/layout';
 @import 'components/masthead';
 @import 'components/nav';

--- a/src/materials/components/button.html
+++ b/src/materials/components/button.html
@@ -3,5 +3,7 @@ notes: |
   These are notes associated with this `button` component.
 links:
   MDN Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
+labels:
+  - inprogress
 ---
 <button class="button">Submit</button>

--- a/src/views/layouts/includes/f-item-header-content.html
+++ b/src/views/layouts/includes/f-item-header-content.html
@@ -1,0 +1,12 @@
+{{#if data.labels}}
+	<ul class="f-Item-labels f-u-listInline">
+		{{#each data.labels}}
+			<li><span class="f-Label f-Label--{{this}}">{{this}}</span></li>
+		{{/each}}
+	</ul>
+{{/if}}
+{{#if notes}}
+	<div class="f-Item-notes" data-f-toggle="notes">
+		{{{notes}}}
+	</div>
+{{/if}}

--- a/src/views/layouts/includes/f-item.html
+++ b/src/views/layouts/includes/f-item.html
@@ -2,22 +2,14 @@
 
 	<div class="f-Item-header">
 		<h2 class="f-Item-heading" data-f-toggle="labels">{{displayName name}}</h2>
-		{{#if notes}}
-			<div class="f-Item-notes" data-f-toggle="notes">
-				{{{notes}}}
-			</div>
-		{{/if}}
+		{{> f-item-header-content this}}
 	</div>
 	{{#if items}}
 		{{#each items}}
 			<div class="f-Item" id="{{@key}}">
 				<div class="f-Item-header">
 					<h3 class="f-Item-heading" data-f-toggle="labels">{{displayName name}}</h3>
-					{{#if notes}}
-						<div class="f-Item-notes" data-f-toggle="notes">
-							{{{notes}}}
-						</div>
-					{{/if}}
+					{{> f-item-header-content this}}
 				</div>
 				{{> f-item-content this}}
 			</div>


### PR DESCRIPTION
This PR introduces another front-end feature, labels.

In previous projects, we referred to this as `status`. To make things really extensible in the future, I thought it might make sense to borrow GitHub's "labels" vocabulary instead, and to also allow for multiple ones if we so choose.

Here's a typical use case:

![screen shot 2015-05-11 at 3 37 20 pm](https://cloud.githubusercontent.com/assets/69633/7576549/dab0988c-f7f3-11e4-8be4-ddb530ebb0c2.png)

But you could also use other ones (in this case, we have a style for `deprecated`, but none for `totoro`):

![screen shot 2015-05-11 at 3 39 50 pm](https://cloud.githubusercontent.com/assets/69633/7576566/001502c0-f7f4-11e4-82df-0dec31fcef17.png)
